### PR TITLE
ais - Streams.extract* should filter out messages that fail NMEA checksum and do so by default

### DIFF
--- a/ais/src/main/java/au/gov/amsa/ais/rx/Streams.java
+++ b/ais/src/main/java/au/gov/amsa/ais/rx/Streams.java
@@ -460,20 +460,6 @@ public class Streams {
         }
     };
 
-    private static boolean containsWeirdCharacters(String s) {
-        if (s == null)
-            return false;
-        else {
-            for (char ch : s.toCharArray()) {
-                if (ch < 32 && ch != 10 && ch != 13) {
-                    log.warn("ch=" + (int) ch);
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
     public static final Func1<NmeaMessage, TimestampedAndLine<AisMessage>> TO_AIS_MESSAGE_AND_LINE = nmea -> {
         String line = nmea.toLine();
         try {

--- a/ais/src/main/java/au/gov/amsa/ais/rx/Streams.java
+++ b/ais/src/main/java/au/gov/amsa/ais/rx/Streams.java
@@ -277,7 +277,7 @@ public class Streams {
 
     public static final Func1<String, Optional<NmeaMessage>> LINE_TO_NMEA_MESSAGE = line -> {
         try {
-            return Optional.of(NmeaUtil.parseNmea(line));
+            return Optional.of(NmeaUtil.parseNmea(line, true));
         } catch (RuntimeException e) {
             return Optional.empty();
         }

--- a/ais/src/main/java/au/gov/amsa/util/nmea/NmeaMessageParser.java
+++ b/ais/src/main/java/au/gov/amsa/util/nmea/NmeaMessageParser.java
@@ -15,13 +15,22 @@ public class NmeaMessageParser {
     private static final String PARAMETER_DELIMITER = ",";
     private static final String CODE_DELIMITER = ":";
 
+    public NmeaMessage parse(String line) {
+        return parse(line, false);
+    }
+    
     /**
-     * Return an {@link NmeaMessage} from the given NMEA line.
+     * Return an {@link NmeaMessage} from the given NMEA line. If validate checksum
+     * is true and the line fails the checksum check then an
+     * {@link NmeaMessageParseException) is thrown.
      * 
      * @param line
-     * @return
+     * @return parsed message
+     * @throws NmeaMessageParseException if tag block badly formed or no checksum
+     *                                   found or if validateChecksum is true and
+     *                                   line fails the checksum check
      */
-    public NmeaMessage parse(String line) {
+    public NmeaMessage parse(String line, boolean validateChecksum) {
         LinkedHashMap<String, String> tags = new LinkedHashMap<>();
 
         String remaining;
@@ -32,6 +41,7 @@ public class NmeaMessageParser {
                         "no matching \\ symbol to finish tag block: " + line);
             if (tagFinish == 0)
                 throw new NmeaMessageParseException("tag block is empty or not terminated");
+            // TODO if validateChecksum is true then validate the tag block checksum
             tags = extractTags(line.substring(1, tagFinish));
             remaining = line.substring(tagFinish + 1);
         } else
@@ -43,8 +53,13 @@ public class NmeaMessageParser {
             if (!remaining.contains("*"))
                 throw new NmeaMessageParseException("checksum delimiter * not found");
             items = getNmeaItems(remaining);
-            // TODO validate message using checksum
             checksum = remaining.substring(remaining.indexOf('*') + 1);
+            if (validateChecksum) {
+                String calculatedChecksum = NmeaUtil.getChecksumWhenHasNoTagBlock(remaining);
+                if (!checksum.equalsIgnoreCase(calculatedChecksum)) {
+                    throw new NmeaMessageParseException("stated checksum does not match calculated");
+                }
+            }
         } else {
             items = new String[] {};
             // TODO decide what value to put here

--- a/ais/src/main/java/au/gov/amsa/util/nmea/NmeaMessageParser.java
+++ b/ais/src/main/java/au/gov/amsa/util/nmea/NmeaMessageParser.java
@@ -24,7 +24,8 @@ public class NmeaMessageParser {
      * is true and the line fails the checksum check then an
      * {@link NmeaMessageParseException) is thrown.
      * 
-     * @param line
+     * @param line NMEA line (without EOL terminator)
+     * @param validateChecksum if true then throws NmeaMessageParseException on invalid checksum
      * @return parsed message
      * @throws NmeaMessageParseException if tag block badly formed or no checksum
      *                                   found or if validateChecksum is true and

--- a/ais/src/main/java/au/gov/amsa/util/nmea/NmeaUtil.java
+++ b/ais/src/main/java/au/gov/amsa/util/nmea/NmeaUtil.java
@@ -63,9 +63,12 @@ public final class NmeaUtil {
     public static String getChecksum(String sentence) {
         return getChecksum(sentence, true);
     }
-
+    
+    public static String getChecksumWhenHasNoTagBlock(String sentence) {
+        return getChecksumWhenHasNoTagBlock(sentence, true, 0);
+    }
+    
     public static String getChecksum(String sentence, boolean ignoreLeadingDollarOrExclamation) {
-
         int startIndex;
         // Start after tag block
         if (sentence.startsWith("\\")) {
@@ -74,10 +77,15 @@ public final class NmeaUtil {
                 throw new AisParseException("no closing \\ for tag block");
         } else
             startIndex = 0;
+        return getChecksumWhenHasNoTagBlock(sentence, ignoreLeadingDollarOrExclamation, startIndex);
+    }
+
+    private static String getChecksumWhenHasNoTagBlock(String sentenceWithoutTagBlock, boolean ignoreLeadingDollarOrExclamation,
+            int startIndex) {
         // Loop through all chars to get a checksum
         int checksum = 0;
-        for (int i = startIndex; i < sentence.length(); i++) {
-            char ch = sentence.charAt(i);
+        for (int i = startIndex; i < sentenceWithoutTagBlock.length(); i++) {
+            char ch = sentenceWithoutTagBlock.charAt(i);
             if (ignoreLeadingDollarOrExclamation && (ch == '$' || ch == '!')) {
                 // Ignore the dollar sign
             } else if (ch == '*') {
@@ -104,7 +112,11 @@ public final class NmeaUtil {
     private static NmeaMessageParser nmeaParser = new NmeaMessageParser();
 
     public static NmeaMessage parseNmea(String line) {
-        return nmeaParser.parse(line);
+        return parseNmea(line, false);
+    }
+        
+    public static NmeaMessage parseNmea(String line, boolean validateChecksum) {
+        return nmeaParser.parse(line, validateChecksum);
     }
     
     public static String insertKeyValueInTagBlock(String line, String name, String value) {

--- a/ais/src/test/java/au/gov/amsa/util/nmea/NmeaMessageParserTest.java
+++ b/ais/src/test/java/au/gov/amsa/util/nmea/NmeaMessageParserTest.java
@@ -24,11 +24,25 @@ public class NmeaMessageParserTest {
         assertNull(n.getRelativeTimeMillis());
         assertNull(n.getText());
         assertNull(n.getUnixTimeMillis());
+        assertEquals("hh", n.getChecksum());
+        assertEquals("14", n.calculateChecksum());
         assertEquals("$ABVSI", n.getItems().get(0));
         assertEquals("r3669961", n.getItems().get(1));
         assertEquals(8, n.getItems().size());
     }
-
+    
+    @Test(expected = NmeaMessageParseException.class)
+    public void testNmeaMessageParserFailsChecksum() {
+        String line = "\\g:3-3-1234*hh\\$ABVSI,r3669961,1,013536.96326433,1386,-98,,*hh";
+        NmeaUtil.parseNmea(line, true);
+    }
+    
+    @Test
+    public void testNmeaMessageParserPassesChecksum() {
+        String line = "\\g:3-3-1234*hh\\$ABVSI,r3669961,1,013536.96326433,1386,-98,,*14";
+        NmeaUtil.parseNmea(line, true);
+    }
+    
     @Test
     public void testParsingOfTimeAndSourceInTagBlock() {
         String line = "\\g:1-2-1234,s:r3669961,c:1120959341*hh\\!ABVDM,1,1,1,B,…..,0*hh";

--- a/ais/src/test/java/au/gov/amsa/util/nmea/NmeaUtilTest.java
+++ b/ais/src/test/java/au/gov/amsa/util/nmea/NmeaUtilTest.java
@@ -44,6 +44,18 @@ public class NmeaUtilTest {
     public void testChecksumTwoLineMessage() {
         assertEquals(CHECKSUM2, NmeaUtil.getChecksum(MESSAGE2A + MESSAGE2B, false));
     }
+    
+    @Test
+    public void testNmeaMessageParserChecksum() {
+        String line = "\\g:3-3-1234*hh\\$ABVSI,r3669961,1,013536.96326433,1386,-98,,*hh";
+        assertEquals("14", NmeaUtil.getChecksum(line));
+    }
+    
+    @Test
+    public void testNmeaMessageParserChecksumWhenNoTagBlock() {
+        String line = "$ABVSI,r3669961,1,013536.96326433,1386,-98,,*hh";
+        assertEquals("14", NmeaUtil.getChecksum(line));
+    }
 
     @Test
     public void testCreateProprietaryHeartbeatLine() {


### PR DESCRIPTION
NMEA messages can carry two checksums, one being for the tag block and the other for the NMEA sentence. 

This PR ensures that messages that fail the NMEA sentence checksum (only) are filtered out by the NMEA parser. 

Tag block checksum checking is for a later PR.

Should satisfy concerns of #44, though if a high number of messages have bad checksums then control flow for filtering those relies on throwing and catching Exceptions which is computationally expensive. Going ahead with this design for the moment based on the assumption that the proportion of messages with bad checksums is low.

CC @Matthimatiker 