### PR TITLE
reduce allocations by avoiding throwing

### DIFF
--- a/ais/pom.xml
+++ b/ais/pom.xml
@@ -287,5 +287,28 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>bench</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>${exec.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>java</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <mainClass>au.gov.amsa.ais.BenchmarksAis</mainClass>
+                            <classpathScope>test</classpathScope>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/ais/pom.xml
+++ b/ais/pom.xml
@@ -52,6 +52,7 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.12.0</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/ais/pom.xml
+++ b/ais/pom.xml
@@ -292,7 +292,7 @@
             </build>
         </profile>
         <profile>
-            <id>bench</id>
+            <id>main</id>
             <build>
                 <plugins>
                     <plugin>

--- a/ais/pom.xml
+++ b/ais/pom.xml
@@ -10,6 +10,9 @@
     <artifactId>ais</artifactId>
     <name>${project.artifactId}</name>
     <description>Utilities for parsing AIS NMEA and XML messages and for processing AIS message streams.</description>
+    <properties>
+        <benchmarkClass></benchmarkClass>
+    </properties>
     <dependencies>
 
         <dependency>
@@ -179,6 +182,7 @@
                                         <argument>3</argument>
                                         <argument>-jvmArgs</argument>
                                         <argument>-Xmx512m</argument>
+                                        <argument>${benchmarkClass}</argument>
                                     </arguments>
                                 </configuration>
                             </execution>
@@ -303,7 +307,7 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <mainClass>au.gov.amsa.ais.BenchmarksAis</mainClass>
+                            <mainClass>au.gov.amsa.ais.BenchmarksDecodeManyNmea</mainClass>
                             <classpathScope>test</classpathScope>
                         </configuration>
                     </plugin>

--- a/ais/src/main/java/au/gov/amsa/ais/AisNmeaMessage.java
+++ b/ais/src/main/java/au/gov/amsa/ais/AisNmeaMessage.java
@@ -179,14 +179,14 @@ public class AisNmeaMessage {
      * 
      * @return timestamped message
      */
-	public Timestamped<AisMessage> getTimestampedMessage() {
-		Long time = getTime();
-		if (time == null) {
+    public Timestamped<AisMessage> getTimestampedMessage() {
+        Long time = getTime();
+        if (time == null) {
             return null;
-		} else {
+        } else {
             return Timestamped.create(getMessage(), getTime());
-		}
-	}
+        }
+    }
 
 	/**
 	 * Returns the checksum (last field in the NMEA line).

--- a/ais/src/main/java/au/gov/amsa/ais/AisNmeaMessage.java
+++ b/ais/src/main/java/au/gov/amsa/ais/AisNmeaMessage.java
@@ -85,23 +85,13 @@ public class AisNmeaMessage {
 
 	/**
 	 * Returns the {@link Talker} corresponding to the first two characters of
-	 * the message format type (e.g. AIVDM -> AI).
+	 * the message format type (e.g. AIVDM -> AI). If not present or not recognized
+	 * then returns {@code Talker.UNKNOWN}.
 	 * 
-	 * @return
+	 * @return talker
 	 */
 	public Talker getTalker() {
 		return nmea.getTalker();
-	}
-
-	/**
-	 * Returns the checksum field at the end of the NMEA line. Does not
-	 * <i>calculate</i> the checksum.
-	 * 
-	 * @param nmea
-	 * @return
-	 */
-	private static String getChecksum(NmeaMessage nmea) {
-		return nmea.getChecksum();
 	}
 
 	/**

--- a/ais/src/main/java/au/gov/amsa/ais/AisNmeaMessage.java
+++ b/ais/src/main/java/au/gov/amsa/ais/AisNmeaMessage.java
@@ -182,12 +182,20 @@ public class AisNmeaMessage {
 			return Timestamped.create(getMessage(), getTime());
 	}
 
+    /**
+     * Returns null if there is no timestamp otherwise returns a timestamped
+     * message. Note that null is returned instead of using an Optional to reduce
+     * allocation pressures.
+     * 
+     * @return timestamped message
+     */
 	public Timestamped<AisMessage> getTimestampedMessage() {
 		Long time = getTime();
-		if (time == null)
-			throw new RuntimeException("nmea did not have timestamp");
-		else
+		if (time == null) {
+		    return null;
+		} else {
 			return Timestamped.create(getMessage(), getTime());
+		}
 	}
 
 	/**

--- a/ais/src/main/java/au/gov/amsa/ais/AisNmeaMessage.java
+++ b/ais/src/main/java/au/gov/amsa/ais/AisNmeaMessage.java
@@ -182,9 +182,9 @@ public class AisNmeaMessage {
 	public Timestamped<AisMessage> getTimestampedMessage() {
 		Long time = getTime();
 		if (time == null) {
-		    return null;
+            return null;
 		} else {
-			return Timestamped.create(getMessage(), getTime());
+            return Timestamped.create(getMessage(), getTime());
 		}
 	}
 

--- a/ais/src/main/java/au/gov/amsa/ais/NmeaStreamProcessor.java
+++ b/ais/src/main/java/au/gov/amsa/ais/NmeaStreamProcessor.java
@@ -88,7 +88,7 @@ public class NmeaStreamProcessor {
 	 * @param line
 	 * @param arrivalTime
 	 */
-	synchronized void line(String line, long arrivalTime) {
+	void line(String line, long arrivalTime) {
 
 		if (count.incrementAndGet() % logCountFrequency == 0)
 			log.info("count=" + count.get() + ",buffer size=" + lines.size());

--- a/ais/src/main/java/au/gov/amsa/ais/rx/Streams.java
+++ b/ais/src/main/java/au/gov/amsa/ais/rx/Streams.java
@@ -444,6 +444,9 @@ public class Streams {
             try {
                 AisNmeaMessage n = new AisNmeaMessage(nmea);
                 Timestamped<AisMessage> m = n.getTimestampedMessage();
+                if (m == null) {
+                    return Optional.empty();
+                }
                 // if (m.message() instanceof AisShipStaticA) {
                 // AisShipStaticA s = (AisShipStaticA) m.message();
                 // if (logWarnings

--- a/ais/src/main/java/au/gov/amsa/util/nmea/NmeaMessageParser.java
+++ b/ais/src/main/java/au/gov/amsa/util/nmea/NmeaMessageParser.java
@@ -57,7 +57,7 @@ public class NmeaMessageParser {
             checksum = remaining.substring(remaining.indexOf('*') + 1).trim();
             if (validateChecksum) {
                 String calculatedChecksum = NmeaUtil.getChecksumWhenHasNoTagBlock(remaining);
-                if (!checksum.equalsIgnoreCase(calculatedChecksum)) {
+                if (!checksum.equals(calculatedChecksum)) {
                     throw new NmeaMessageParseException("stated checksum does not match calculated");
                 }
             }

--- a/ais/src/main/java/au/gov/amsa/util/nmea/NmeaUtil.java
+++ b/ais/src/main/java/au/gov/amsa/util/nmea/NmeaUtil.java
@@ -7,12 +7,15 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import com.github.davidmoten.guavamini.Sets;
 
 import au.gov.amsa.ais.AisParseException;
 
 public final class NmeaUtil {
+
+    private static final String[] EMPTY = new String[] {};
 
     private static final char BACKSLASH = '\\';
 
@@ -106,10 +109,21 @@ public final class NmeaUtil {
             }
         }
         // Return the checksum formatted as a two-character hexadecimal
-        String s = Integer.toHexString(checksum % 256);
-        if (s.length() == 1)
-            s = "0" + s;
-        return s.toUpperCase();
+        return toUpperCaseHexString(checksum % 256);
+    }
+    
+    private static final String[] hexes = IntStream //
+            .range(0, 256) //
+            .mapToObj(x -> {
+                String s = Integer.toHexString(x).toUpperCase();
+                if (s.length() == 1) {
+                    s = "0" + s;
+                }
+                return s;
+            }).collect(Collectors.toList()).toArray(EMPTY);
+    
+    private static String toUpperCaseHexString(int n) {
+        return hexes[n];
     }
 
     private static NmeaMessageParser nmeaParser = new NmeaMessageParser();

--- a/ais/src/main/java/au/gov/amsa/util/nmea/NmeaUtil.java
+++ b/ais/src/main/java/au/gov/amsa/util/nmea/NmeaUtil.java
@@ -1,9 +1,12 @@
 package au.gov.amsa.util.nmea;
 
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.github.davidmoten.guavamini.Sets;
 
@@ -220,15 +223,21 @@ public final class NmeaUtil {
         s.append(",a:");
         s.append(arrivalTime);
     }
-
+    
+    private static final Map<String, Talker> talkers = Arrays.asList(Talker.values()).stream()
+            .collect(Collectors.toMap(t -> t.name(), t -> t));
+    
     public static Talker getTalker(String s) {
         if (s == null)
-            return null;
+            return Talker.UNKNOWN;
         else {
-            try {
-                return Talker.valueOf(s);
-            } catch (RuntimeException e) {
+            // don't use Talker.valueOf because it throws when s not valid Talker 
+            // and throw exceptions are bad for performance due allocations
+            Talker t = talkers.get(s);
+            if (t == null) {
                 return Talker.UNKNOWN;
+            } else {
+                return t;
             }
         }
     }

--- a/ais/src/main/java/au/gov/amsa/util/nmea/NmeaUtil.java
+++ b/ais/src/main/java/au/gov/amsa/util/nmea/NmeaUtil.java
@@ -57,10 +57,9 @@ public final class NmeaUtil {
      */
     public static boolean isValid(String sentence) {
         // Compare the characters after the asterisk to the calculation
-
         try {
             return sentence.substring(sentence.lastIndexOf("*") + 1)
-                    .equalsIgnoreCase(getChecksum(sentence));
+                    .equals(getChecksum(sentence));
         } catch (AisParseException e) {
             return false;
         }

--- a/ais/src/test/java/au/gov/amsa/ais/AisNmeaMessageTest.java
+++ b/ais/src/test/java/au/gov/amsa/ais/AisNmeaMessageTest.java
@@ -1,7 +1,6 @@
 package au.gov.amsa.ais;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.Date;

--- a/ais/src/test/java/au/gov/amsa/ais/BenchmarksAis.java
+++ b/ais/src/test/java/au/gov/amsa/ais/BenchmarksAis.java
@@ -74,12 +74,10 @@ public class BenchmarksAis {
     }
 
 	public static void main(String[] args) {
-	    int i = 0;
 		while (true) {
 		    Streams //
 	          .extractFixes(Observable.from(nmeaLines)) //
 	          .subscribe();
-		    System.out.println(i++);
 		}
 	}
 

--- a/ais/src/test/java/au/gov/amsa/ais/BenchmarksAis.java
+++ b/ais/src/test/java/au/gov/amsa/ais/BenchmarksAis.java
@@ -22,6 +22,7 @@ public class BenchmarksAis {
 	private static final List<String> nmeaLines = Streams
 			.nmeaFromGzip(new File("src/test/resources/ais.txt.gz")).toList()
 			.toBlocking().single();
+	private static final List<String> nmeaLinesShorter = nmeaLines.subList(0, 1000);
 
 	@Benchmark
 	public void parseShipStaticNmeaMessage() {
@@ -48,15 +49,6 @@ public class BenchmarksAis {
 		n.getMessage();
 	}
 
-	// @Benchmark
-	// public void parseAisPositionANmeaMessageUsingDmaLibrary() throws
-	// SentenceException,
-	// AisMessageException, SixbitException {
-	// Vdm vdm = new Vdm();
-	// vdm.parse(aisPositionA);
-	// AisMessage3.getInstance(vdm);
-	// }
-
 	@Benchmark
 	public void parseAisPositionBNmeaMessage() {
 		AisNmeaMessage n = new AisNmeaMessage(aisPositionB);
@@ -74,20 +66,20 @@ public class BenchmarksAis {
 	}
 	
    @Benchmark
-    public void parseManyFixes() throws IOException {
-        // process 44K lines
+    public void parseManyFixesShorter() throws IOException {
+        // process 1K lines
        Streams //
-          .extractFixes(Observable.from(nmeaLines)) //
+          .extractFixes(Observable.from(nmeaLinesShorter)) //
           .subscribe();
     }
 
 	public static void main(String[] args) {
-		System.setProperty("a", "");
+	    int i = 0;
 		while (true) {
-			AisNmeaMessage n = new AisNmeaMessage(aisPositionA);
-			n.getMessage();
-			n = new AisNmeaMessage(shipStaticA);
-			n.getMessage();
+		    Streams //
+	          .extractFixes(Observable.from(nmeaLines)) //
+	          .subscribe();
+		    System.out.println(i++);
 		}
 	}
 

--- a/ais/src/test/java/au/gov/amsa/ais/BenchmarksAis.java
+++ b/ais/src/test/java/au/gov/amsa/ais/BenchmarksAis.java
@@ -19,12 +19,8 @@ public class BenchmarksAis {
 	private static final String shipStaticA = "\\s:rEV02,c:1334337326*5A\\!ABVDM,1,1,0,2,57PBtv01sb5IH`PR221LE986222222222222220l28?554000:kQEhhDm31H20DPSmD`880,2*40";
 	private static final String aisPositionA = "\\s:rEV02,c:1334337326*5A\\!AIVDM,1,1,,B,18JSad001i5gcaArTICimQTT068t,0*4A";
 	private static final String aisPositionB = "\\s:MSQ - Mt Cootha,c:1426803365*73\\!AIVDM,1,1,,A,B7P?n900Irg8IHL4RblF?wRToP06,0*1B";
-	private static final List<String> nmeaLines = Streams
-			.nmeaFromGzip(new File("src/test/resources/ais.txt.gz")).toList()
-			.toBlocking().single();
-	private static final List<String> nmeaLinesShorter = nmeaLines.subList(0, 1000);
 
-	@Benchmark
+//	@Benchmark
 	public void parseShipStaticNmeaMessage() {
 		AisNmeaMessage n = new AisNmeaMessage(shipStaticA);
 		n.getMessage();
@@ -54,31 +50,4 @@ public class BenchmarksAis {
 		AisNmeaMessage n = new AisNmeaMessage(aisPositionB);
 		n.getMessage();
 	}
-
-	@Benchmark
-	public void parseManyNmeaMessage() throws IOException {
-		// process 44K lines
-		Observable //
-		    .from(nmeaLines) //
-		    .map(Streams.LINE_TO_NMEA_MESSAGE) //
-			.compose(Streams.<NmeaMessage> valueIfPresent()) //
-			.subscribe();
-	}
-	
-   @Benchmark
-    public void parseManyFixesShorter() throws IOException {
-        // process 1K lines
-       Streams //
-          .extractFixes(Observable.from(nmeaLinesShorter)) //
-          .subscribe();
-    }
-
-	public static void main(String[] args) {
-		while (true) {
-		    Streams //
-	          .extractFixes(Observable.from(nmeaLines)) //
-	          .subscribe();
-		}
-	}
-
 }

--- a/ais/src/test/java/au/gov/amsa/ais/BenchmarksDecodeManyNmea.java
+++ b/ais/src/test/java/au/gov/amsa/ais/BenchmarksDecodeManyNmea.java
@@ -1,0 +1,49 @@
+package au.gov.amsa.ais;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+import au.gov.amsa.ais.rx.Streams;
+import au.gov.amsa.util.nmea.NmeaMessage;
+import rx.Observable;
+
+@State(Scope.Benchmark)
+public class BenchmarksDecodeManyNmea {
+
+    private static final List<String> nmeaLines = Streams.nmeaFromGzip(new File("src/test/resources/ais.txt.gz"))
+            .toList().toBlocking().single();
+
+    private static final List<String> nmeaLinesShorter = nmeaLines.subList(0, 1000);
+
+    @Benchmark
+    public void parseManyFixesShorter() throws IOException {
+        // process 1K lines
+        Streams //
+                .extractFixes(Observable.from(nmeaLinesShorter)) //
+                .subscribe();
+    }
+
+    @Benchmark
+    public void parseManyNmeaMessage() throws IOException {
+        // process 44K lines
+        Observable //
+                .from(nmeaLines) //
+                .map(Streams.LINE_TO_NMEA_MESSAGE) //
+                .compose(Streams.<NmeaMessage>valueIfPresent()) //
+                .subscribe();
+    }
+
+    public static void main(String[] args) {
+        while (true) {
+            Streams //
+                    .extractFixes(Observable.from(nmeaLines)) //
+                    .subscribe();
+        }
+    }
+
+}

--- a/ais/src/test/java/au/gov/amsa/util/nmea/NmeaUtilTest.java
+++ b/ais/src/test/java/au/gov/amsa/util/nmea/NmeaUtilTest.java
@@ -113,7 +113,8 @@ public class NmeaUtilTest {
 
     @Test
     public void testGetTalkerGivenNullString() {
-        assertNull(NmeaUtil.getTalker(null));
+        assertEquals(Talker.UNKNOWN,
+                NmeaUtil.getTalker(null));
     }
 
     @Test


### PR DESCRIPTION
as discussed in #71, after inspection of JDK Mission Control - TLAB Allocations - Flame View the throwing of a RuntimeException when a timestamp was not present (a very common event) had a significant effect on allocation pressure (understandably). Returning null instead (returning an Optional was not done to avoid increasing allocations) improved throughput by 60% in the benchmark below (which processes 1000 typical (for AMSA) NMEA lines repeatedly).

Main method analyzed:
```java
    while (true) {
	Streams //
	     .extractFixes(Observable.from(nmeaLines)) //
	     .subscribe();
    }
```

JMH before this change:
```
Result "au.gov.amsa.ais.BenchmarksAis.parseManyFixesShorter":
  127.104 ±(99.9%) 5.038 ops/s [Average]
  (min, avg, max) = (119.368, 127.104, 129.733), stdev = 3.332
  CI (99.9%): [122.066, 132.143] (assumes normal distribution)
```

JMH after this change:
```
Result "au.gov.amsa.ais.BenchmarksAis.parseManyFixesShorter":
  204.845 ±(99.9%) 36.975 ops/s [Average]
  (min, avg, max) = (147.838, 204.845, 223.359), stdev = 24.457
  CI (99.9%): [167.871, 241.820] (assumes normal distribution)
```
